### PR TITLE
Check if deployment ok with artifactci mode =`lazy`

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yaml
+++ b/.github/workflows/docs_build_and_deploy.yaml
@@ -49,4 +49,3 @@ jobs:
         with:
           secret_input: ${{ secrets.GITHUB_TOKEN }}
           use-make: true
-          # use-artifactci: true

--- a/.github/workflows/docs_build_and_deploy.yaml
+++ b/.github/workflows/docs_build_and_deploy.yaml
@@ -32,7 +32,7 @@ jobs:
           python-version: 3.12
           use-make: true
           fetch-tags: true
-          use-artifactci: eager
+          use-artifactci: lazy
           check-links: false
 
   deploy_sphinx_docs:
@@ -49,4 +49,4 @@ jobs:
         with:
           secret_input: ${{ secrets.GITHUB_TOKEN }}
           use-make: true
-          use-artifactci: true
+          # use-artifactci: true

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,7 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
-
+import subprocess
 
 # -- Project information -----------------------------------------------------
 
@@ -22,7 +22,18 @@ copyright = '2025, Neuroinformatics Unit'
 author = 'Neuroinformatics Unit'
 
 # The full version, including alpha/beta/rc tags
-release = '0.0.1'
+try:
+    result = subprocess.run(
+        ['git', 'describe', '--tags', '--abbrev=0'],
+        capture_output=True,
+        text=True,
+        check=True
+    )
+    release = result.stdout.strip().lstrip('v')
+    print(release)
+    print(result)
+except (subprocess.CalledProcessError, FileNotFoundError):
+    release = "0.0.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,8 +30,6 @@ try:
         check=True
     )
     release = result.stdout.strip().lstrip('v')
-    print(release)
-    print(result)
 except (subprocess.CalledProcessError, FileNotFoundError):
     release = "0.0.0"
 


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
To test if we need to set the mode of the `artifact.ci`  upload action to `eager` in order to have a successful deployment.


**What does this PR do?**
- Uses the `artifact.ci` action from @lochhh's fork with the root path fix
- Sets the mode to `lazy`
- Comments out the `use-artifactci` input for the deployment action (since that is no longer available in `main`)
- Adds the git-tag to the title of the home page to quickly verify things are correct.

## References

This was to check if some of the changes in [PR88](https://github.com/neuroinformatics-unit/actions/pull/88) are necessary.

movement [PR643](https://github.com/neuroinformatics-unit/movement/pull/643) is also related 


## How has this PR been tested?

I tagged the last commit of this PR ([b84388e](https://github.com/neuroinformatics-unit/sphinx-deployment-test/pull/3/commits/b84388e37d05df061791615b192ee3b0e856aaaa), which uses `lazy` mode) with `v0.0.1rc04` and verified that the docs are deployed with the correct tag ([here](https://github.com/neuroinformatics-unit/sphinx-deployment-test/actions/runs/16500671235))
 
 
## Is this a breaking change?

\

## Does this PR require an update to the documentation?
\

## Checklist:

- [x] The code has been tested locally
- [ n/a ] Tests have been added to cover all new functionality
- [ n/a ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
