### PR TITLE
Try artifactci `eager` mode with and without use-make

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yaml
+++ b/.github/workflows/docs_build_and_deploy.yaml
@@ -32,7 +32,7 @@ jobs:
           python-version: 3.12
           use-make: true
           fetch-tags: true
-          use-artifactci: lazy
+          use-artifactci: eager
           check-links: false
 
   deploy_sphinx_docs:

--- a/.github/workflows/docs_build_and_deploy.yaml
+++ b/.github/workflows/docs_build_and_deploy.yaml
@@ -30,7 +30,6 @@ jobs:
       - uses: neuroinformatics-unit/actions/build_sphinx_docs@ch-artifactci-fork
         with:
           python-version: 3.12
-          use-make: true
           fetch-tags: true
           use-artifactci: eager
           check-links: false
@@ -48,4 +47,3 @@ jobs:
       - uses: neuroinformatics-unit/actions/deploy_sphinx_docs@main
         with:
           secret_input: ${{ secrets.GITHUB_TOKEN }}
-          use-make: true

--- a/.github/workflows/docs_build_and_deploy.yaml
+++ b/.github/workflows/docs_build_and_deploy.yaml
@@ -30,6 +30,7 @@ jobs:
       - uses: neuroinformatics-unit/actions/build_sphinx_docs@ch-artifactci-fork
         with:
           python-version: 3.12
+          use-make: true
           fetch-tags: true
           use-artifactci: eager
           check-links: false
@@ -47,3 +48,4 @@ jobs:
       - uses: neuroinformatics-unit/actions/deploy_sphinx_docs@main
         with:
           secret_input: ${{ secrets.GITHUB_TOKEN }}
+          use-make: true


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

**What does this PR do?**
Tests that
- the [direct URL](https://github.com/neuroinformatics-unit/sphinx-deployment-test/actions/runs/16502281922) to the preview is generated when using `use-make` with `use-artifactci: eager`
- the [direct URL](https://github.com/neuroinformatics-unit/sphinx-deployment-test/actions/runs/16502386120) to the preview is generated when using the default sphinx-build with `use-artifactci: eager`

## References

Please reference any existing issues/PRs that relate to this PR.

## How has this PR been tested?

Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.

## Is this a breaking change?

If this PR breaks any existing functionality, please explain how and why.

## Does this PR require an update to the documentation?

If any features have changed, or have been added. Please explain how the
documentation has been updated.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
